### PR TITLE
fix size for horizontal-stack

### DIFF
--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -20,6 +20,10 @@ class TempometerGaugeCard extends HTMLElement {
     const cardConfig = Object.assign({}, config);
     if (!cardConfig.scale) cardConfig.scale = "50px";
 
+    if (config.horizontal) {
+      cardConfig.scale = "40px";
+    }
+    
     const entityParts = this._splitEntityAndAttribute(cardConfig.entity);
     cardConfig.entity = entityParts.entity;
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;


### PR DESCRIPTION
I update the JS for fix size for horizontal-stack.
If I use vertical cards no problem, but with horizontal the size it's wrong.