### PR TITLE
Min max entities attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ Add it as a custom card to your lovelace : `'custom:tempometer-gauge-card'`.
 ### Card options
 | **Option** | **Type** | **Description** |
 |-|:-:|-|
-| `entity` ***(required)*** | string | The entity to track. |
-| `attribute`| string | The entity attribute to track. |
+| `entity` ***(required)*** | string | The entity to track. Can be followed by an attribute to track `entity.attribute)`|
 | `min` ***(required)*** | number | The gauge's minimum value |
 | `max` ***(required)*** | number | The gauge's maximum value |
-| `entity_min` | string | The entity that define the minimum pressure/temperature reached (you have to create this entity, the card will not compute it !) |
-| `entity_max` | string | The entity that define the maximum pressure/temerature reached (you have to create this entity, the card will not compute it !) |
+| `entity_min` | string | The entity that define the minimum reached. Can be followed by an attribute to track `entity.attribute)` (you have to create this entity, the card will not compute it !) |
+| `entity_max` | string | The entity that define the maximum reached. Can be followed by an attribute to track `entity.attribute)` (you have to create this entity, the card will not compute it !) |
 | `title` | string | Card title to show. |
 | `style` | string | Set this to `thermometer`, `humidity` or `custom` to change icons. (Default will be barometer theme, custom will need icon1, icon2, icon3 !) |
 | `measurement` | string | Custom unit of measurement |

--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -30,11 +30,11 @@ class TempometerGaugeCard extends HTMLElement {
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
     const entityMinParts = this._splitEntityAndAttribute(cardConfig.entity_min);
-    cardConfig.entity_min = entityMinParts.entity_min;
+    cardConfig.entity_min = entityMinParts.entity;
     if (entityMinParts.attribute) cardConfig.minAttribute = entityMinParts.attribute;
 
     const entityMaxParts = this._splitEntityAndAttribute(cardConfig.entity_max);
-    cardConfig.entity_max = entityMaxParts.entity_max;
+    cardConfig.entity_max = entityMaxParts.entity;
     if (entityMaxParts.attribute) cardConfig.maxAttribute = entityMaxParts.attribute;
 
     let card_style = cardConfig.style;

--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -29,7 +29,15 @@ class TempometerGaugeCard extends HTMLElement {
     cardConfig.entity = entityParts.entity;
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
-	let card_style = cardConfig.style;
+    const entityMinParts = this._splitEntityAndAttribute(cardConfig.entity_min);
+    cardConfig.entity_min = entityParts.entity_min;
+    if (entityMinParts.attribute) cardConfig.minAttribute = entityMinParts.attribute;
+
+    const entityMaxParts = this._splitEntityAndAttribute(cardConfig.entity_max);
+    cardConfig.entity_max = entityParts.entity_max;
+    if (entityMaxParts.attribute) cardConfig.maxAttribute = entityMaxParts.attribute;
+
+    let card_style = cardConfig.style;
     const card = document.createElement('ha-card');
     const content = document.createElement('div');
     const style = document.createElement('style');
@@ -332,12 +340,12 @@ class TempometerGaugeCard extends HTMLElement {
     var maxEntityState = null;
     var minEntityState = null;
     if (config.entity_max !== undefined) {
-        maxEntityState = this._getEntityStateValue(hass.states[config.entity_max], config.attribute);
+        maxEntityState = this._getEntityStateValue(hass.states[config.entity_max], config.maxAttribute);
     } else {
         root.getElementById("recentMax").style.display = 'none';
     }
     if (config.entity_min !== undefined) {
-        minEntityState = this._getEntityStateValue(hass.states[config.entity_min], config.attribute);
+        minEntityState = this._getEntityStateValue(hass.states[config.entity_min], config.minAttribute);
     } else {
         root.getElementById("recentMin").style.display = 'none';
     }

--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -30,11 +30,11 @@ class TempometerGaugeCard extends HTMLElement {
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
     const entityMinParts = this._splitEntityAndAttribute(cardConfig.entity_min);
-    cardConfig.entity_min = entityParts.entity_min;
+    cardConfig.entity_min = entityMinParts.entity_min;
     if (entityMinParts.attribute) cardConfig.minAttribute = entityMinParts.attribute;
 
     const entityMaxParts = this._splitEntityAndAttribute(cardConfig.entity_max);
-    cardConfig.entity_max = entityParts.entity_max;
+    cardConfig.entity_max = entityMaxParts.entity_max;
     if (entityMaxParts.attribute) cardConfig.maxAttribute = entityMaxParts.attribute;
 
     let card_style = cardConfig.style;

--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -1,4 +1,4 @@
-console.info(`%c TEMPOMETER-CARD \n%c      v1.1       `, 'color: orange; font-weight: bold; background: black', 'color: white; font-weight: bold; background: dimgray');
+console.info(`%c TEMPOMETER-CARD \n%c      v1.2       `, 'color: orange; font-weight: bold; background: black', 'color: white; font-weight: bold; background: dimgray');
 class TempometerGaugeCard extends HTMLElement {
   constructor() {
     super();


### PR DESCRIPTION
Fixes #23 
Get the possibility to specify an attribute to entity_min and entity_max

example : 
`entity_min: vacuum.xiaomi_vacuum_cleaner.cleaning_time`