### PR TITLE
Fixed "TypeError: Cannot read property 'split' of undefined"

### DIFF
--- a/tempometer-gauge-card.js
+++ b/tempometer-gauge-card.js
@@ -29,14 +29,18 @@ class TempometerGaugeCard extends HTMLElement {
     cardConfig.entity = entityParts.entity;
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
-    const entityMinParts = this._splitEntityAndAttribute(cardConfig.entity_min);
-    cardConfig.entity_min = entityMinParts.entity;
-    if (entityMinParts.attribute) cardConfig.minAttribute = entityMinParts.attribute;
+    if (cardConfig.entity_min !== undefined) {
+      const entityMinParts = this._splitEntityAndAttribute(cardConfig.entity_min);
+      cardConfig.entity_min = entityMinParts.entity;
+      if (entityMinParts.attribute) cardConfig.minAttribute = entityMinParts.attribute;
+    }
 
-    const entityMaxParts = this._splitEntityAndAttribute(cardConfig.entity_max);
-    cardConfig.entity_max = entityMaxParts.entity;
-    if (entityMaxParts.attribute) cardConfig.maxAttribute = entityMaxParts.attribute;
-
+    if (cardConfig.entity_max !== undefined) {
+      const entityMaxParts = this._splitEntityAndAttribute(cardConfig.entity_max);
+      cardConfig.entity_max = entityMaxParts.entity;
+      if (entityMaxParts.attribute) cardConfig.maxAttribute = entityMaxParts.attribute;
+    }
+	    
     let card_style = cardConfig.style;
     const card = document.createElement('ha-card');
     const content = document.createElement('div');


### PR DESCRIPTION
When no 'entity_min' or/and 'entity_max' is defined, the card shows following error "Cannot read property 'split' of undefined" and is not rendered.

> card custom:tempometer-gauge-card TypeError: Cannot read property 'split' of undefined
    at HTMLElement._splitEntityAndAttribute (tempometer-gauge-card.js:267)
    at HTMLElement.setConfig (tempometer-gauge-card.js:32)
    at s (chunk.53174295df05176b2339.js:454)
    at chunk.53174295df05176b2339.js:454
    at u (chunk.53174295df05176b2339.js:454)
    at c (chunk.53174295df05176b2339.js:454)
    at o (chunk.53174295df05176b2339.js:454)
    at HTMLElement.value (chunk.a8fc15b8e5d83f800941.js:2785)
    at HTMLElement.value (chunk.a8fc15b8e5d83f800941.js:2785)
    at HTMLElement.t.addEventListener.once (chunk.a8fc15b8e5d83f800941.js:2785)